### PR TITLE
Resolve use of Placeholder type for empty displays

### DIFF
--- a/app/src/main/kotlin/fuzzd/generator/ast/operators/BinaryOperator.kt
+++ b/app/src/main/kotlin/fuzzd/generator/ast/operators/BinaryOperator.kt
@@ -73,7 +73,7 @@ sealed class BinaryOperator(val precedence: Int, private val symbol: String) : A
     sealed class DataStructureBinaryOperator(precedence: Int, symbol: String) : BinaryOperator(precedence, symbol) {
         override fun outputType(t1: Type, t2: Type): Type = BoolType
         override fun supportsInput(t1: Type, t2: Type): Boolean =
-            t1 == t2 && (t1 is SetType || t1 is MultisetType || t1 is MapType || t1 is SequenceType)
+            (t1 is LiteralType && t1 == t2) || t1 is SetType || t1 is MultisetType || t1 is MapType || t1 is SequenceType
     }
 
     object DataStructureEqualityOperator : DataStructureBinaryOperator(4, "==")


### PR DESCRIPTION
Fixes issue where binary operations on empty data structure types wasn't allowed due to use of Placeholder type